### PR TITLE
fix bugs and bump to v0.2.32

### DIFF
--- a/adapter.ts
+++ b/adapter.ts
@@ -190,6 +190,7 @@ export interface Part {
 export interface PutObjectOption {
     progressCallback?: ProgressCallback;
     throttle?: Throttle;
+    crc32?: string,
 }
 
 export interface GetObjectStreamOption {

--- a/kodo-http-client.ts
+++ b/kodo-http-client.ts
@@ -28,6 +28,7 @@ export interface RequestOptions {
     uploadProgress?: (uploaded: number, total: number) => void,
     uploadThrottle?: Throttle,
     stats?: RequestStats,
+    appendAuthorization?: boolean,
 
     // for uplog
     apiName: string;
@@ -79,6 +80,7 @@ export class KodoHttpClient {
             uploadProgress: options.uploadProgress,
             uploadThrottle: options.uploadThrottle,
             stats: options.stats,
+            appendAuthorization: options.appendAuthorization,
 
             // for uplog
             apiName: options.apiName,

--- a/kodo.ts
+++ b/kodo.ts
@@ -385,7 +385,11 @@ export class Kodo implements Adapter {
                 form.append(`x-qn-meta-${metaKey}`, metaValue);
             }
         }
-        form.append('crc32', CRC32.unsigned(data));
+        if (option?.crc32) {
+            form.append('crc32', option.crc32);
+        } else {
+            form.append('crc32', CRC32.unsigned(data));
+        }
 
         const fileOption: FormData.AppendOptions = {
             filename: originalFileName,
@@ -402,6 +406,7 @@ export class Kodo implements Adapter {
             form,
             uploadProgress: option?.progressCallback,
             uploadThrottle: option?.throttle,
+            appendAuthorization: false,
 
             // for uplog
             apiName: 'putObject',
@@ -971,6 +976,7 @@ export class Kodo implements Adapter {
             },
             uploadProgress: option?.progressCallback,
             uploadThrottle: option?.throttle,
+            appendAuthorization: false,
 
             // for uplog
             apiName: 'uploadPart',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kodo-s3-adapter-sdk",
-  "version": "0.2.31",
+  "version": "0.2.32",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kodo-s3-adapter-sdk",
-  "version": "0.2.31",
+  "version": "0.2.32",
   "description": "Adapter for Kodo & S3 API",
   "main": "dist/index.js",
   "repository": "github.com/bachue/kodo-s3-adapter-sdk",

--- a/uploader.ts
+++ b/uploader.ts
@@ -103,6 +103,7 @@ export class Uploader {
             {
                 progressCallback: putFileOption?.putCallback?.progressCallback,
                 throttle,
+                crc32: putFileOption?.crc32,
             },
         );
     }
@@ -180,6 +181,9 @@ export class Uploader {
         let progressCallback: ProgressCallback | undefined;
         if (putFileOption.putCallback?.progressCallback) {
             progressCallback = (partUploaded: number, _partTotal: number) => {
+                if (this.aborted) {
+                    throw Uploader.userCanceledError;
+                }
                 putFileOption.putCallback?.progressCallback?.(uploaded + partUploaded, fileSize);
             };
         }
@@ -194,6 +198,9 @@ export class Uploader {
                 throttle: makeThrottle(),
             },
         );
+        if (this.aborted) {
+            throw Uploader.userCanceledError;
+        }
 
         data = undefined;
         const part: Part = { etag: output.etag, partNumber };
@@ -229,6 +236,7 @@ export interface PutFileOption {
     uploadThreshold?: number;
     uploadThrottleGroup?: ThrottleGroup;
     uploadThrottleOption?: ThrottleOptions;
+    crc32?: string;
 }
 
 export interface RecoveredOption {


### PR DESCRIPTION
- upload disable create useless qiniu auth;
- form upload allows incoming crc32 from outside to prevent block;
- split upload prevent callback after abort;